### PR TITLE
fix(composer): remove version field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "jardisadapter/dbconnection",
     "description": "DbConnection is a factory to create PDO database connections and delivers a professional PDO connection wrapper.",
-    "version": "1.0.0",
     "type": "library",
     "license": "PolyForm-Noncommercial-1.0.0",
     "minimum-stability": "stable",


### PR DESCRIPTION
Version is managed by git tags via auto-release workflow. The version field in composer.json is unnecessary and can cause conflicts.