### PR TITLE
fix(deps): bump squizlabs/php_codesniffer to 3.13.6 (security)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "10.5.63",
         "phpstan/phpstan": "2.1.56",
-        "squizlabs/php_codesniffer": "3.13.5"
+        "squizlabs/php_codesniffer": "3.13.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Advisory PKSA-rdkp-vv9z-mjkg (OS Command Injection, betroffen < 3.13.6) trifft den bisher gepinnten `squizlabs/php_codesniffer` 3.13.5.
- Composer verweigert mit dem Default `block-insecure` jede frische Aufloesung, solange der Pin steht — ein frischer `composer install` (z.B. CI) scheitert im Install-Schritt.
- Der exakte Pin (`==3.13.5`) bestand bereits vor dieser Aenderung, wird hier nur vorwaerts bewegt (`3.13.6`), nicht neu eingefuehrt.

Zielversion: v1.0.1 (patch)

## Test plan
- [x] `make install` nach Entfernen von composer.lock: frische Aufloesung zeigt `Upgrading squizlabs/php_codesniffer (3.13.5 => 3.13.6)`
- [x] `make phpcs` — exit 0
- [x] `make phpstan` — exit 0
- [x] `make phpunit` — 181 tests, 328 assertions, exit 0